### PR TITLE
Complete Phase 4-5 consistency improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,3 +182,9 @@ incus exec <container> -- cat /var/log/cloud-init-output.log
 # Ansible debug
 ansible-playbook main.yml --check --diff --limit <host>
 ```
+
+### Required paths
+* On a mac ensure that the following paths are searched for commands:
+  * /opt/homebrew/bin
+  * /opt/homebrew/sbin
+

--- a/CONSISTENCY_PLAN.md
+++ b/CONSISTENCY_PLAN.md
@@ -61,14 +61,14 @@ This document outlines the plan to fix identified inconsistencies in the NAS inf
 ## Phase 4: Template and Configuration Normalization (Low Priority)
 
 ### 8. Standardize Template Delimiters
-- **Status**: ⏳ Pending
+- **Status**: ✅ Completed (2025-01-13)
 - **Issue**: Mixed custom vs standard Jinja2 delimiters
 - **Fix**: Evaluate necessity of custom delimiters, standardize where possible
 - **Files**: `app-proxy-caddy` role templates and tasks
 - **Impact**: Easier template maintenance and consistency
 
 ### 9. Normalize Package Variable Names
-- **Status**: ⏳ Pending
+- **Status**: ✅ Completed (2025-01-13)
 - **Issue**: Same variable names (`packages_to_install`) used across different roles
 - **Fix**: Use role-prefixed variable names (`caddy_packages_to_install`)
 - **Files**: Role `vars/main.yml` files
@@ -77,14 +77,14 @@ This document outlines the plan to fix identified inconsistencies in the NAS inf
 ## Phase 5: Advanced Consistency Improvements (Low Priority)
 
 ### 10. Standardize Service Management Patterns
-- **Status**: ⏳ Pending
+- **Status**: ✅ Completed (2025-01-13)
 - **Issue**: Mixed service module usage (`ansible.builtin.service` vs `ansible.builtin.systemd`)
 - **Fix**: Use `ansible.builtin.systemd` consistently for systemd services
 - **Files**: All handler files and service management tasks
 - **Impact**: Consistent service management approach
 
 ### 11. Normalize Tag Naming Strategy
-- **Status**: ⏳ Pending
+- **Status**: ✅ Completed (2025-01-13)
 - **Issue**: Mixed granularity and naming patterns for tags
 - **Fix**: Establish consistent tag taxonomy (service-level, infrastructure-level)
 - **Files**: All playbooks and task files with tags
@@ -131,26 +131,53 @@ This document outlines the plan to fix identified inconsistencies in the NAS inf
   - Role documentation: Comprehensive README.md files for all custom roles
   - Test infrastructure: Basic test framework in place
   - Ansible syntax check: All playbooks valid after structural changes
+- **Phase 4-5 Testing (2025-01-13)**: ✅ All tests passed
+  - Template delimiter standardization: Jinja2 delimiters consistent in Caddyfile templates
+  - Package variable naming: Role-prefixed variables prevent conflicts
+  - Service management: All handlers and tasks use ansible.builtin.systemd consistently
+  - Tag naming: Kebab-case convention already in place, verified consistent
+  - Ansible syntax check: All playbooks valid after Phase 4-5 changes
 
 ## Progress Tracking
 - Plan created: 2025-01-11
-- Last updated: 2025-01-11
-- Overall progress: 7/11 items completed
+- Last updated: 2025-01-13
+- Overall progress: 11/11 items completed
 - Phase 1 (High Priority): ✅ Completed
 - Phase 2 (Medium Priority): ✅ Completed  
 - Phase 3 (Medium Priority): ✅ Completed
+- Phase 4 (Low Priority): ✅ Completed
+- Phase 5 (Low Priority): ✅ Completed
 
 ## Next Steps
 1. ✅ Phase 1 completed and tested successfully
 2. ✅ Phase 2 completed and merged successfully
 3. ✅ Phase 3 completed and merged successfully
-4. **Current Priority**: Begin Phase 4 (Template and Configuration Normalization)
-   - Standardize template delimiters
-   - Normalize package variable names
-3. **Testing Protocol**: 
-   - Test each phase before proceeding to next
-   - Run `terraform validate` and `terraform plan` for infrastructure changes
-   - Run `ansible-playbook --syntax-check` for playbook changes
-4. **Ongoing**:
-   - Update this plan as items are completed
-   - Document any deviations or issues encountered
+4. ✅ Phase 4 completed and tested successfully
+5. ✅ Phase 5 completed and tested successfully
+
+## Project Completion Summary
+
+🎉 **All 11 consistency improvements have been successfully implemented!**
+
+### Final Testing Protocol
+Before merging the `consistency-phase4` branch to main:
+1. Run `terraform validate` and `terraform plan` to verify infrastructure integrity
+2. Run `ansible-playbook --syntax-check` on all playbooks
+3. Review all changes for completeness
+4. Merge to main branch
+
+### Key Achievements
+- **Code Style**: Standardized YAML booleans, handler naming, and file modes
+- **Variables**: Consistent OnePassword lookups and role-prefixed variable names
+- **Structure**: Complete role directory structure with proper documentation
+- **Templates**: Consistent Jinja2 delimiter usage
+- **Services**: Uniform systemd module usage across all roles
+- **Tags**: Verified kebab-case naming convention
+
+### Impact
+The codebase now follows consistent patterns throughout, improving:
+- Maintainability and readability
+- Reduced risk of variable conflicts
+- Better documentation coverage
+- Standardized service management
+- Consistent configuration patterns

--- a/roles/app-proxy-caddy/handlers/main.yml
+++ b/roles/app-proxy-caddy/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart caddy
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: caddy
     state: restarted

--- a/roles/app-proxy-caddy/tasks/main.yml
+++ b/roles/app-proxy-caddy/tasks/main.yml
@@ -16,7 +16,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='nas-portainer.fzymgc.house',
         site_upstream_url='https://nas-container-apps.incus:9443',
@@ -39,7 +39,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='nas-storj.fzymgc.house',
         site_upstream_url='http://192.168.20.200:20909',
@@ -61,7 +61,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='nas-syncthing-sean.fzymgc.house',
         site_upstream_url='http://192.168.20.200:20910',
@@ -83,7 +83,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='nas-storj.fzymgc.house',
         site_upstream_url='http://192.168.20.200:20909',
@@ -105,7 +105,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='nas.fzymgc.house',
         site_upstream_url='https://192.168.20.200:444',
@@ -128,7 +128,7 @@
     insertafter: EOF
     append_newline: true
     create: true
-    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%',
+    content: "{{ lookup('ansible.builtin.template', 'Caddyfile-site.j2', variable_start_string='%[', variable_end_string=']%', block_start_string='%[-', block_end_string='%]',
       template_vars=dict(
         site_fqdn='searxng.fzymgc.house',
         site_upstream_url='https://192.168.20.200:8888',

--- a/roles/app-proxy-caddy/templates/Caddyfile-site.j2
+++ b/roles/app-proxy-caddy/templates/Caddyfile-site.j2
@@ -1,6 +1,6 @@
 %[ site_fqdn ]% {
   encode zstd gzip
-  {% if site_tls_cloudflare -%}
+  %[- if site_tls_cloudflare %]
   tls {
     issuer acme %[ acme_ca ]% {
       email %[ acme_account_email ]%
@@ -8,19 +8,19 @@
       dns cloudflare %[ cloudflare_api_token ]%
       # propagation_delay 60s
       # propagation_timeout -1
-    {% if use_local_resolvers -%}
+    %[- if use_local_resolvers %]
       resolvers 127.0.0.1
-    {% endif -%}
+    %[- endif %]
     }
   }
-  {% endif %}
+  %[- endif %]
   reverse_proxy %[ site_upstream_url ]% {
     header_up Host {upstream_hostport}
-    {% if site_upstream_tls -%}
+    %[- if site_upstream_tls %]
     transport http {
       tls_server_name %[ tls_server_name ]%
     }
-    {% endif %}
+    %[- endif %]
   }
   %[ site_additional_config | default('') | indent(2)  ]%
 }

--- a/roles/ares/defaults/main.yml
+++ b/roles/ares/defaults/main.yml
@@ -20,4 +20,4 @@ ares_packages_to_install:
   - valkey
   - valkey-redis-compat
 
-ruby_version: 3.1.2
+ares_ruby_version: 3.1.2

--- a/roles/ares/handlers/main.yml
+++ b/roles/ares/handlers/main.yml
@@ -1,27 +1,27 @@
 - name: Restart caddy
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: caddy
     state: restarted
 
 - name: Restart edge-node caddy
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: caddy
     state: restarted
   delegate_to: edge-node
 
 - name: Restart tailscaled
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: tailscaled
     state: restarted
 
 - name: Restart edge-node haproxy
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: haproxy
     state: restarted
   delegate_to: edge-node
 
 - name: Restart valkey
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: valkey
     state: restarted
 

--- a/roles/ares/tasks/main.yml
+++ b/roles/ares/tasks/main.yml
@@ -90,16 +90,16 @@
   ansible.builtin.shell:
     cmd: |
       source /home/ares/.rvm/scripts/rvm
-      rvm install {{ ruby_version }}
-      rvm --default use {{ ruby_version }}
-    creates:  /home/ares/.rvm/rubies/ruby-{{ ruby_version }}/bin/ruby
+      rvm install {{ ares_ruby_version }}
+      rvm --default use {{ ares_ruby_version }}
+    creates:  /home/ares/.rvm/rubies/ruby-{{ ares_ruby_version }}/bin/ruby
 
 - name: Update .profile with rvm config
   ansible.builtin.blockinfile:
     dest: /home/ares/.profile
     block: |
       source /home/ares/.rvm/scripts/rvm
-      rvm --default use {{ ruby_version }}
+      rvm --default use {{ ares_ruby_version }}
     marker: "# {mark} rvm ANSIBLE MANAGED BLOCK"
 
 - name: Install required gems
@@ -109,7 +109,7 @@
       source /home/ares/.rvm/scripts/rvm
       gem install bundler
       gem install rake
-    creates: /home/ares/.rvm/rubies/ruby-{{ ruby_version }}/bin/bundler
+    creates: /home/ares/.rvm/rubies/ruby-{{ ares_ruby_version }}/bin/bundler
 
 - name: Declare safe git dirs
   become_user: ares
@@ -197,7 +197,7 @@
     cmd: |
       cd ~/aresmush
       source /home/ares/.rvm/scripts/rvm
-      rvm use {{ ruby_version }}
+      rvm use {{ ares_ruby_version }}
       bin/configure host_name={{ game_host_name }}.{{ game_host_domain }}
       touch game/.configured
     creates: /home/ares/aresmush/game/.configured
@@ -230,7 +230,7 @@
     cmd: |
       cd ~/aresmush
       source /home/ares/.rvm/scripts/rvm
-      rvm use {{ ruby_version }}
+      rvm use {{ ares_ruby_version }}
       bin/wipedb && touch game/.dbinitialized
     creates: /home/ares/aresmush/game/.dbinitialized
 
@@ -252,7 +252,7 @@
     cmd: |
       cd ~/aresmush
       source /home/ares/.rvm/scripts/rvm
-      rvm use {{ ruby_version }}
+      rvm use {{ ares_ruby_version }}
       bundle exec rake initmigrations
       touch game/.dbinitialmigrations-complete
     creates: /home/ares/aresmush/game/.dbinitialmigrations-complete

--- a/roles/caddy/defaults/main.yml
+++ b/roles/caddy/defaults/main.yml
@@ -8,4 +8,4 @@ caddy_packages_to_install:
   - apt-transport-https
   - ca-certificates
 
-use_local_resolvers: false
+caddy_use_local_resolvers: false

--- a/roles/caddy/handlers/main.yml
+++ b/roles/caddy/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
 - name: Restart caddy
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: caddy
     state: restarted

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -155,7 +155,7 @@
   tags: mail
 
 - name: Configure fail2ban
-  ansible.builtin.service:
+  ansible.builtin.systemd:
     name: fail2ban
     state: started
     enabled: true


### PR DESCRIPTION
## Summary
This PR completes the final phases (4 and 5) of the consistency improvement project, bringing the total to 11/11 completed items.

## Phase 4 Completed
- ✅ **Standardized template delimiters**: Fixed mixed Jinja2 delimiter usage in Caddyfile templates
- ✅ **Normalized package variable names**: Added role prefixes to prevent variable conflicts

## Phase 5 Completed  
- ✅ **Standardized service management**: Migrated all handlers/tasks to use `ansible.builtin.systemd`
- ✅ **Normalized tag naming**: Verified existing kebab-case convention is consistent

## Test Results
All tests passed successfully:
- `terraform validate`: ✅ Success
- `terraform plan`: ✅ Shows only expected minor in-place update
- `ansible-playbook --syntax-check`: ✅ All playbooks valid

## Files Changed
- Updated `CONSISTENCY_PLAN.md` to mark all phases complete
- Added macOS Homebrew path documentation to `CLAUDE.md`
- Standardized Jinja2 delimiters in Caddy role templates
- Updated variable names with role prefixes
- Migrated service modules to systemd

This completes the entire consistency improvement project\! 🎉

🤖 Generated with [Claude Code](https://claude.ai/code)