### PR TITLE
feat: Add Terraform module for GitHub Actions runner container

### DIFF
--- a/docs/github-runner-plan.md
+++ b/docs/github-runner-plan.md
@@ -1,0 +1,48 @@
+# GitHub Actions Runner Container Plan
+
+## Overview
+This plan outlines the implementation of a local GitHub Actions runner using Incus containers within the existing NAS infrastructure.
+
+## Implementation Steps
+
+### 1. Terraform Infrastructure Module (`tf/modules/github-runner/`)
+- Create container with appropriate resources (4-8 CPU cores, 8-16GB RAM)
+- Attach to internal network for security
+- Configure storage volume for runner workspace
+
+### 2. Cloud-init Profile Configuration
+- Install Docker and build tools
+- Create runner user with sudo privileges
+- Configure systemd service for runner daemon
+- Pre-install common CI/CD dependencies
+
+### 3. Ansible Role (`roles/github-runner/`)
+- Download and install GitHub Actions runner binary
+- Configure runner registration with PAT/app token
+- Set up Docker-in-Docker for container workflows
+- Configure runner labels and capabilities
+
+### 4. Security & Networking
+- Isolate on internal network with outbound-only access
+- Configure fail2ban and firewall rules
+- Implement runner token rotation
+- Set up monitoring with Prometheus metrics
+
+### 5. Orchestration Playbook
+- Integrate with existing `main.yml` workflow
+- Add `github-runners` tag for selective deployment
+- Support multiple runner instances with unique names
+
+## Task Tracking
+
+1. ✅ Create Terraform module for GitHub runner container (PR: feat/github-runner-terraform-module)
+   - Created module structure in `tf/modules/github-runner/`
+   - Configured container with 4 CPU cores, 8GB RAM, 50GB storage
+   - Internal network only for security
+   - Integrated into main.tf
+2. Create cloud-init profile for runner initialization
+3. Create Ansible role for GitHub runner setup
+4. Add runner registration with GitHub organization/repo
+5. Configure Docker-in-Docker support for container workflows
+6. Create playbook to orchestrate runner deployment
+7. Add security hardening and network isolation

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -70,3 +70,11 @@ module "precipice-server" {
   server_database_dir = "/mnt/main/fzymgc-house/incus/storage/precipice/database"
 }
 
+module "github-runners" {
+  depends_on                    = [module.profiles]
+  source                        = "./modules/github-runner"
+  container_bridge_network_name = module.base.container_bridge_network_name
+  runner_count                  = 1
+  runner_name                   = "github-runner"
+}
+

--- a/tf/modules/github-runner/main.tf
+++ b/tf/modules/github-runner/main.tf
@@ -1,0 +1,57 @@
+data "incus_project" "default" {
+  name = "default"
+}
+
+resource "incus_instance" "github_runner" {
+  count       = var.runner_count
+  name        = var.runner_count > 1 ? "${var.runner_name}-${format("%02d", count.index + 1)}" : var.runner_name
+  description = "GitHub Actions Runner ${count.index + 1}"
+  image       = "images:ubuntu/oracular/cloud"
+  profiles    = ["default", "base"]
+
+  config = {
+    "user.access_interface" = "eth1"
+    "raw.idmap" = <<-EOT
+      uid 568 568
+      gid 568 568
+    EOT
+    "limits.cpu"    = var.cpu_cores
+    "limits.memory" = var.memory_limit
+  }
+
+  # Internal network interface only for security
+  device {
+    name = "eth1"
+    type = "nic"
+    properties = {
+      nictype = "bridged"
+      parent  = var.container_bridge_network_name
+    }
+  }
+
+  # Runner workspace storage
+  device {
+    name = "runner-workspace"
+    type = "disk"
+    properties = {
+      path = "/home/runner/workspace"
+      pool = "incus-lvm-thinpool"
+      size = var.disk_size
+    }
+  }
+
+  wait_for {
+    type  = "ipv4"
+    nic   = "eth1"
+    delay = "30s"
+  }
+}
+
+resource "ansible_host" "github_runner" {
+  count = var.runner_count
+  name  = incus_instance.github_runner[count.index].name
+  variables = {
+    ansible_user = "fzymgc"
+    ansible_host = incus_instance.github_runner[count.index].ipv4_address
+  }
+}

--- a/tf/modules/github-runner/outputs.tf
+++ b/tf/modules/github-runner/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_names" {
+  description = "Names of the GitHub runner instances"
+  value       = incus_instance.github_runner[*].name
+}
+
+output "instance_ipv4_addresses" {
+  description = "IPv4 addresses of the GitHub runner instances"
+  value       = incus_instance.github_runner[*].ipv4_address
+}
+
+output "instance_ipv6_addresses" {
+  description = "IPv6 addresses of the GitHub runner instances"
+  value       = incus_instance.github_runner[*].ipv6_address
+}

--- a/tf/modules/github-runner/variables.tf
+++ b/tf/modules/github-runner/variables.tf
@@ -1,0 +1,34 @@
+variable "runner_name" {
+  description = "Name for the GitHub runner instance"
+  type        = string
+  default     = "github-runner-01"
+}
+
+variable "runner_count" {
+  description = "Number of runner instances to create"
+  type        = number
+  default     = 1
+}
+
+variable "container_bridge_network_name" {
+  description = "The name of the Incus bridge network to attach the container to"
+  type        = string
+}
+
+variable "cpu_cores" {
+  description = "Number of CPU cores to allocate to the runner"
+  type        = string
+  default     = "4"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the runner container"
+  type        = string
+  default     = "8GiB"
+}
+
+variable "disk_size" {
+  description = "Size of the disk for runner workspace"
+  type        = string
+  default     = "50GiB"
+}

--- a/tf/modules/github-runner/versions.tf
+++ b/tf/modules/github-runner/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    incus = {
+      source  = "lxc/incus"
+      version = ">= 0.3.0"
+    }
+    ansible = {
+      source  = "ansible/ansible"
+      version = ">= 1.3.0"
+    }
+    onepassword = {
+      source  = "1Password/onepassword"
+      version = ">= 2.1.2"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Create new Terraform module for GitHub Actions runner containers
- Configure containers with appropriate resources for CI/CD workloads
- Implement security-first approach with internal network isolation

## Changes
- Add `tf/modules/github-runner/` module with:
  - 4 CPU cores, 8GB RAM, 50GB storage defaults
  - Internal network only (no external access)
  - Support for multiple runner instances
  - Dedicated workspace storage volume
- Integrate module into `tf/main.tf`
- Add implementation plan documentation

## Test plan
- [ ] Run `terraform init` to initialize the module
- [ ] Run `terraform plan` to verify configuration
- [ ] Apply changes and verify container creation
- [ ] Verify container has only internal network access

🤖 Generated with [Claude Code](https://claude.ai/code)