### PR TITLE
feat: Add cloud-init profile for GitHub Actions runner

### DIFF
--- a/docs/github-runner-plan.md
+++ b/docs/github-runner-plan.md
@@ -47,7 +47,15 @@ This plan outlines the implementation of a local GitHub Actions runner using Inc
      - Pinned Ubuntu image version (20250712_07:42)
      - Created comprehensive module README.md
      - Removed unused data source
-2. Create cloud-init profile for runner initialization
+2. ✅ Create cloud-init profile for runner initialization (PR: feat/github-runner-cloudinit-profile)
+   - Created dedicated `github-runner` profile in `tf/modules/profiles/`
+   - Configured cloud-init with:
+     - Docker and Docker Compose installation
+     - Development tools (Node.js, .NET SDKs, GitHub CLI)
+     - Runner user with sudo and docker access
+     - Systemd service template for GitHub runner
+   - Enabled Docker-in-Docker support with privileged container
+   - Updated GitHub runner module to use the new profile
 3. Create Ansible role for GitHub runner setup
 4. Add runner registration with GitHub organization/repo
 5. Configure Docker-in-Docker support for container workflows

--- a/tf/modules/github-runner/README.md
+++ b/tf/modules/github-runner/README.md
@@ -84,7 +84,7 @@ This module implements several security best practices:
 
 - Incus must be installed and configured
 - The specified bridge network must exist
-- The base profile must be configured with cloud-init
+- The base and github-runner profiles must exist (created by profiles module)
 - Storage pool must exist and have sufficient space
 
 ## Integration with GitHub

--- a/tf/modules/github-runner/main.tf
+++ b/tf/modules/github-runner/main.tf
@@ -6,12 +6,16 @@ data "incus_profile" "base" {
   name = "base"
 }
 
+data "incus_profile" "github_runner" {
+  name = "github-runner"
+}
+
 resource "incus_instance" "github_runner" {
   count       = var.runner_count
   name        = var.runner_count > 1 ? "${var.runner_name}-${format("%02d", count.index + 1)}" : var.runner_name
   description = "GitHub Actions Runner ${count.index + 1}"
   image       = var.container_image
-  profiles    = ["default", "base"]
+  profiles    = ["default", "base", "github-runner"]
 
   config = {
     "user.access_interface" = "eth1"

--- a/tf/modules/profiles/github-runner/cloud-init.user-data.yaml
+++ b/tf/modules/profiles/github-runner/cloud-init.user-data.yaml
@@ -1,0 +1,106 @@
+#cloud-config
+# GitHub Runner specific cloud-init configuration
+
+# Merge with base configuration
+merge_how:
+  - name: list
+    settings: [append]
+  - name: dict
+    settings: [recurse_array]
+
+# Additional packages for GitHub Actions runner
+packages:
+  - docker.io
+  - docker-compose
+  - jq
+  - unzip
+  - libicu-dev
+  - libssl-dev
+  - ca-certificates
+  - software-properties-common
+  - apt-transport-https
+  - gnupg
+  - lsb-release
+  - nodejs
+  - npm
+  - dotnet-sdk-8.0
+  - dotnet-sdk-6.0
+
+# Create runner user and directories
+users:
+  - name: runner
+    uid: 1001
+    shell: /bin/bash
+    groups: [docker, sudo]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    home: /home/runner
+
+# Docker configuration
+write_files:
+  - path: /etc/docker/daemon.json
+    content: |
+      {
+        "log-driver": "json-file",
+        "log-opts": {
+          "max-size": "10m",
+          "max-file": "3"
+        },
+        "storage-driver": "overlay2"
+      }
+
+# Runner directories and permissions
+runcmd:
+  # Enable and start Docker
+  - systemctl enable docker
+  - systemctl start docker
+  
+  # Create runner directories
+  - mkdir -p /home/runner/actions-runner
+  - mkdir -p /home/runner/workspace
+  - mkdir -p /home/runner/.config
+  
+  # Set ownership
+  - chown -R runner:runner /home/runner
+  
+  # Add runner user to docker group
+  - usermod -aG docker runner
+  
+  # Configure git for runner user
+  - sudo -u runner git config --global init.defaultBranch main
+  - sudo -u runner git config --global user.name "GitHub Runner"
+  - sudo -u runner git config --global user.email "runner@localhost"
+  
+  # Install GitHub CLI
+  - |
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    apt-get update
+    apt-get install -y gh
+
+# Configure systemd service for runner (placeholder - will be configured by Ansible)
+  - |
+    cat > /etc/systemd/system/github-runner.service << 'EOF'
+    [Unit]
+    Description=GitHub Actions Runner
+    After=network.target docker.service
+    Wants=docker.service
+
+    [Service]
+    Type=simple
+    User=runner
+    Group=runner
+    WorkingDirectory=/home/runner/actions-runner
+    ExecStart=/home/runner/actions-runner/run.sh
+    Restart=always
+    RestartSec=10
+    KillMode=process
+    KillSignal=SIGTERM
+    TimeoutStopSec=5
+
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+  
+  # Don't enable the service yet - Ansible will handle registration and enablement
+  - systemctl daemon-reload

--- a/tf/modules/profiles/main.tf
+++ b/tf/modules/profiles/main.tf
@@ -33,3 +33,18 @@ resource "incus_profile" "base" {
   }
 }
 
+resource "incus_profile" "github_runner" {
+  name        = "github-runner"
+  description = "GitHub Actions Runner profile"
+
+  config = {
+    "boot.autostart"                       = true
+    "linux.kernel_modules"                 = "br_netfilter,overlay"
+    "security.nesting"                     = true
+    "security.syscalls.intercept.mknod"    = true
+    "security.syscalls.intercept.setxattr" = true
+    "security.privileged"                  = true  # Required for Docker-in-Docker
+    "cloud-init.user-data"                 = file("${path.module}/github-runner/cloud-init.user-data.yaml")
+  }
+}
+


### PR DESCRIPTION
## Summary
- Create dedicated cloud-init profile for GitHub runner containers
- Configure containers with all necessary dependencies and tools
- Enable Docker-in-Docker support for container-based workflows

## Changes
- Add `tf/modules/profiles/github-runner/cloud-init.user-data.yaml` with:
  - Docker and Docker Compose installation
  - Development tools (Node.js, npm, .NET SDKs)
  - GitHub CLI for repository operations
  - Runner user with appropriate permissions
  - Systemd service template for runner daemon
- Update `tf/modules/profiles/main.tf` to create github-runner profile
- Enable privileged mode for Docker-in-Docker support
- Update GitHub runner module to use the new profile

## Cloud-init Features
- Installs all common CI/CD dependencies
- Configures Docker with log rotation
- Creates runner user with sudo and docker access
- Sets up directory structure for runner workspace
- Pre-configures git for the runner user
- Creates systemd service (to be enabled by Ansible after registration)

## Test plan
- [ ] Run `terraform plan` to verify profile creation
- [ ] Apply changes and verify container creation
- [ ] Verify Docker is installed and running in container
- [ ] Check runner user has correct permissions
- [ ] Validate all packages are installed correctly

🤖 Generated with [Claude Code](https://claude.ai/code)