### PR TITLE
docs: Add Terraform plan requirement to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,3 +188,17 @@ ansible-playbook main.yml --check --diff --limit <host>
   * /opt/homebrew/bin
   * /opt/homebrew/sbin
 
+## Important Development Guidelines
+
+### Terraform Changes
+**IMPORTANT**: For any change that involves Terraform files (.tf, .tfvars, or files in tf/ directory), you MUST run `terraform plan` to verify the changes before committing. This ensures:
+- Syntax validation
+- Resource dependency checks
+- State consistency
+- No unintended infrastructure changes
+
+Always run from the tf/ directory:
+```bash
+cd tf/
+terraform plan
+```


### PR DESCRIPTION
## Summary
Add important development guideline to CLAUDE.md requiring `terraform plan` to be run for any Terraform changes.

## Changes
- Added "Important Development Guidelines" section to CLAUDE.md
- Documented requirement to run `terraform plan` before committing Terraform changes
- Listed benefits: syntax validation, dependency checks, state consistency, preventing unintended changes
- Included clear instructions on how to run the command

## Rationale
This guideline helps prevent common issues:
- Syntax errors being committed to the repository
- Breaking changes to infrastructure dependencies
- Terraform state inconsistencies
- Accidental infrastructure modifications

## Impact
This is a documentation-only change that improves development practices for contributors working with Terraform files in this project.

🤖 Generated with [Claude Code](https://claude.ai/code)