### PR TITLE
fix: Fix MAC address generation and network interface configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Master orchestrator that:
 - **`nas-support-playbook.yml`**: Docker, administrative users, system tools
 - **`nas-container-apps-playbook.yml`**: Portainer container management
 - **`ares-servers-playbook.yml`**: AreMUSH gaming servers with Ruby/Valkey
+- **`github-runners-playbook.yml`**: GitHub Actions self-hosted runners
 
 ## Terraform Module Structure
 
@@ -91,6 +92,7 @@ Master orchestrator that:
 - **`nas-support/`**: Support services container
 - **`nas-container-apps/`**: Container application hosting
 - **`ares-server/`**: Gaming server containers
+- **`github-runner/`**: GitHub Actions runner containers
 
 ### Key Files
 - **`main.tf`**: Module orchestration and resource dependencies
@@ -106,7 +108,7 @@ Master orchestrator that:
 
 ### Tagging Strategy
 - All playbooks use consistent tags for selective execution
-- Tags: `incus`, `terraform`, `nas-app-proxy`, `ares-servers`, `nas-support`, `nas-container-apps`
+- Tags: `incus`, `terraform`, `nas-app-proxy`, `ares-servers`, `nas-support`, `nas-container-apps`, `github-runners`
 
 ### Dependencies
 - Terraform provisions infrastructure first
@@ -135,6 +137,12 @@ Master orchestrator that:
 ### `capps-portainer/` Role
 - Portainer deployment for Docker management
 - Container orchestration setup
+
+### `github-runner/` Role
+- GitHub Actions runner installation and configuration
+- Supports organization and repository runners
+- Automatic updates and custom labels
+- Systemd service management
 
 ## Development Notes
 
@@ -202,3 +210,18 @@ Always run from the tf/ directory:
 cd tf/
 terraform plan
 ```
+
+## Documentation Structure
+
+### Documentation Organization
+- **`/docs/`**: All project documentation
+- **`/docs/changes/`**: Implementation plans and bug fix tracking
+  - Update plans as phases complete
+  - Track bug fixes and their resolution status
+  - Document architectural decisions
+
+### GitHub Runner Components
+- **`github-runners-playbook.yml`**: Orchestrates GitHub runner deployment
+- **`tf/modules/github-runner/`**: Terraform module for runner containers
+- **`roles/github-runner/`**: Ansible role for runner configuration
+- **Tags**: `github-runners` for selective deployment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,14 @@ Master orchestrator that:
 - **`ares-servers-playbook.yml`**: AreMUSH gaming servers with Ruby/Valkey
 - **`github-runners-playbook.yml`**: GitHub Actions self-hosted runners
 
-## Terraform Module Structure
+## Terraform Infrastructure
 
-### Infrastructure Modules (`tf/modules/`)
+### Quick Reference
+- **Detailed Terraform Guide**: See `tf/CLAUDE.md` for comprehensive Terraform-specific documentation
+- **Module Location**: `tf/modules/`
+- **State Management**: Terraform Cloud workspace `incus-nas`
+
+### Infrastructure Modules
 - **`base/`**: Core Incus infrastructure (projects, networks, storage)
 - **`profiles/`**: Cloud-init configuration and container profiles
 - **`nas-app-proxy/`**: Reverse proxy container configuration
@@ -94,10 +99,8 @@ Master orchestrator that:
 - **`ares-server/`**: Gaming server containers
 - **`github-runner/`**: GitHub Actions runner containers
 
-### Key Files
-- **`main.tf`**: Module orchestration and resource dependencies
-- **`providers.tf`**: Incus, 1Password, Terraform Cloud providers
-- **`terraform.tfvars`**: Environment-specific variables (not committed)
+### Critical Security Note
+**WARNING**: The `terraform.tfvars` file currently contains exposed tokens. See `tf/CLAUDE.md` for remediation steps.
 
 ## Configuration Patterns
 
@@ -198,18 +201,21 @@ ansible-playbook main.yml --check --diff --limit <host>
 
 ## Important Development Guidelines
 
-### Terraform Changes
-**IMPORTANT**: For any change that involves Terraform files (.tf, .tfvars, or files in tf/ directory), you MUST run `terraform plan` to verify the changes before committing. This ensures:
-- Syntax validation
-- Resource dependency checks
-- State consistency
-- No unintended infrastructure changes
+### Terraform Development
 
-Always run from the tf/ directory:
+**IMPORTANT**: For any Terraform changes, you MUST:
+1. Review `tf/CLAUDE.md` for detailed Terraform guidelines and best practices
+2. Run `terraform plan` before committing any changes
+3. Never commit sensitive values in `terraform.tfvars`
+
+Quick validation:
 ```bash
 cd tf/
+terraform validate
 terraform plan
 ```
+
+For detailed Terraform operations, module patterns, and troubleshooting, see `tf/CLAUDE.md`.
 
 ## Documentation Structure
 

--- a/docs/changes/github-runner-bug-fixes.md
+++ b/docs/changes/github-runner-bug-fixes.md
@@ -1,0 +1,133 @@
+# GitHub Runner Bug Fix Plan
+
+## Overview
+This document outlines the plan to address bugs and issues identified in PR #22 for the GitHub runner infrastructure.
+
+## Priority Classification
+- 🔴 **Critical**: Breaking bugs that prevent functionality
+- 🟡 **High**: Functional bugs that impact operations
+- 🟠 **Medium**: Code quality and best practice issues
+- 🟢 **Low**: Performance optimizations and nice-to-haves
+
+## Issues to Address
+
+### 🔴 Critical Bugs
+
+#### 1. MAC Address Conflicts ✅ FIXED (PR #23)
+**Location**: `tf/modules/github-runner/main.tf:33`
+**Issue**: Hardcoded MAC addresses could conflict with multiple runners
+**Fix Applied**: 
+- Changed from `"00:16:3e:ae:aa:0${count.index + 3}"` to `format("00:16:3e:ae:aa:%02x", count.index + 3)`
+- Now properly generates hexadecimal MAC addresses for 10+ runners
+- **Status**: Completed in PR #23
+
+#### 2. Network Interface Mismatch ✅ FIXED (PR #23)
+**Location**: `tf/modules/github-runner/main.tf:17`
+**Issue**: `user.access_interface` set to eth1 but only eth0 configured
+**Fix Applied**:
+- Changed `user.access_interface` from "eth1" to "eth0"
+- **Status**: Completed in PR #23
+
+### 🟡 High Priority Issues
+
+#### 3. Service Dependencies 🔄 PENDING
+**Location**: `tf/modules/profiles/github-runner/cloud-init.user-data.yaml:156-158`
+**Issue**: GitHub runner service may start before Docker is ready
+**Fix**:
+- Add `After=docker.service` to systemd unit
+- Add `Requires=docker.service` for hard dependency
+- Implement health check before starting runner
+
+#### 4. Missing Error Handling 🔄 PENDING
+**Locations**: 
+- Git configuration: `tf/modules/profiles/github-runner/cloud-init.user-data.yaml:138-141`
+- Package installation: `tf/modules/profiles/github-runner/cloud-init.user-data.yaml:144-149`
+**Fix**:
+- Add `|| true` for non-critical commands
+- Use proper error checking for critical operations
+- Log failures to cloud-init output
+
+### 🟠 Medium Priority Issues
+
+#### 5. DNS Configuration Duplication 🔄 PENDING
+**Location**: `inventory/production.yml:117-118`
+**Issue**: DNS settings duplicated between inventory and cloud-init
+**Fix**:
+- Centralize DNS configuration in group_vars
+- Remove duplication from cloud-init
+- Use Ansible variables for consistency
+
+### 🟢 Low Priority Improvements
+
+#### 6. Performance Optimizations 🔄 PENDING
+- Parallel package installation in cloud-init
+- Use package lists instead of individual installs
+- Consider pre-built container images
+
+#### 7. Test Coverage 🔄 PENDING
+- Add Terraform validation tests
+- Create integration tests for runner deployment
+- Add monitoring and health checks
+
+## Implementation Status
+
+### ✅ Phase 1: Critical Bug Fixes (COMPLETED)
+**PR #23**: https://github.com/fzymgc-house/nas-incus/pull/23
+- ✅ Fixed MAC address generation for multiple runners
+- ✅ Corrected network interface configuration
+- ✅ All tests passed (terraform validate, terraform plan)
+- ✅ PR created and awaiting review
+
+### 🔄 Phase 2: Service Reliability (PENDING)
+- [ ] Fix service dependencies and startup order
+- [ ] Add comprehensive error handling
+- [ ] Test service reliability across reboots
+
+### 🔄 Phase 3: Code Quality (PENDING)
+- [ ] Resolve configuration duplication
+- [ ] Implement proper logging
+- [ ] Add monitoring
+
+### 🔄 Phase 4: Testing & Optimization (FUTURE)
+- [ ] Add test coverage
+- [ ] Performance optimizations
+- [ ] Documentation updates
+
+## Testing Strategy
+
+### Phase 1 Tests (Completed)
+- ✅ Terraform validate passed
+- ✅ Terraform plan showed only expected changes
+- ✅ MAC address generation tested for 10 runners
+- ✅ No unintended infrastructure changes
+
+### Phase 2 Tests (Planned)
+- Service startup verification
+- Reboot testing
+- Docker dependency validation
+- Error recovery testing
+
+### Phase 3 Tests (Planned)
+- Configuration consistency checks
+- Log aggregation verification
+- Monitoring dashboard validation
+
+## Current Branch Status
+- **Current Branch**: `fix/phase1-mac-network-bugs`
+- **PR**: #23 - Awaiting review
+- **Next Branch**: Will create `fix/phase2-service-reliability` after PR #23 is merged
+
+## Success Criteria
+- ✅ No MAC address conflicts with multiple runners
+- ✅ Correct network interface configuration
+- 🔄 Services start reliably on boot
+- 🔄 Runners connect to GitHub successfully
+- 🔄 All tests pass
+- 🔄 No service startup failures
+
+## Timeline
+- ✅ Day 1-2: Critical bug fixes (COMPLETED)
+- 🔄 Day 3-4: Service dependency fixes (NEXT)
+- 🔄 Day 5-7: Error handling and testing
+- 🔄 Week 2: Code quality improvements
+- 🔄 Week 3: Full testing and documentation

--- a/tf/CLAUDE.md
+++ b/tf/CLAUDE.md
@@ -1,0 +1,259 @@
+# CLAUDE.md - Terraform Directory Guide
+
+This file provides specific guidance for working with Terraform infrastructure code in this directory.
+
+## Directory Structure
+
+```
+tf/
+├── main.tf                 # Root module orchestrator
+├── providers.tf           # Provider configurations
+├── variables.tf           # Root-level variables
+├── versions.tf            # Version constraints
+├── terraform.tfvars       # Variable values (SECURITY WARNING: Contains token)
+├── outputs.tf             # Root outputs (currently empty)
+└── modules/
+    ├── base/              # Core infrastructure (project, networks, storage)
+    ├── profiles/          # Incus profiles and cloud-init configs
+    ├── nas-app-proxy/     # Reverse proxy container
+    ├── nas-support/       # Support services container
+    ├── nas-container-apps/# Container application hosting
+    ├── ares-server/       # Gaming server containers
+    └── github-runner/     # GitHub Actions runners
+```
+
+## Module Dependency Order
+
+1. **base** → Creates core infrastructure (networks, storage, project)
+2. **profiles** → Defines container profiles with cloud-init
+3. **container modules** → Deploy specific services using profiles
+
+## Provider Configuration
+
+### Active Providers
+- **Incus**: Container infrastructure management
+  - Remote: `192.168.20.200:2443`
+  - Authentication: Token-based
+  - Auto-generates client certificates
+- **Terraform Cloud**: Remote state management
+  - Organization: `fzymgc-house`
+  - Workspace: `incus-nas`
+
+### Available but Unused
+- **1Password**: Configured for future secrets management
+
+## Best Practices for This Project
+
+### 1. Variable Management
+```hcl
+# DO: Use variables for values that change between environments
+variable "container_count" {
+  description = "Number of containers to create"
+  type        = number
+  default     = 1
+}
+
+# DON'T: Hardcode sensitive values
+# NEVER commit tokens or passwords in terraform.tfvars
+```
+
+### 2. Resource Naming
+- Use descriptive names: `nas-app-proxy`, not `proxy1`
+- Include purpose in name: `github_runner_profile`
+- Be consistent with hyphens vs underscores
+
+### 3. Module Structure
+Each module should have:
+```
+module-name/
+├── main.tf       # Primary resources
+├── variables.tf  # Input variables with descriptions
+├── outputs.tf    # Exported values
+├── versions.tf   # Provider version constraints
+└── README.md     # Module documentation
+```
+
+### 4. Network Configuration
+- External network: macvlan on `bond0`
+- Internal network: bridge on `incusbr0` or `cbr0`
+- MAC addresses: Use `format()` for proper hex generation
+
+### 5. Cloud-init Best Practices
+- Keep cloud-init files focused and minimal
+- Use Ansible for complex configuration
+- Always include package update in cloud-init
+- Set proper file permissions for SSH keys
+
+## Common Operations
+
+### Adding a New Container Module
+1. Create module directory: `modules/service-name/`
+2. Copy structure from existing module
+3. Update cloud-init profile if needed
+4. Add module block to `main.tf`
+5. Run `terraform init` to initialize module
+6. Test with `terraform plan`
+
+### Modifying Existing Infrastructure
+```bash
+# Always plan before applying
+terraform plan -var-file=terraform.tfvars
+
+# Apply specific module only
+terraform apply -target=module.github-runners
+
+# Destroy specific resource
+terraform destroy -target=module.github-runners.incus_instance.github_runner[0]
+```
+
+### Import Existing Resources
+```bash
+# Import format for Incus instances
+terraform import module.base.incus_network.incusbr0 incusbr0
+```
+
+## Security Guidelines
+
+### CRITICAL: Fix Token Exposure
+1. Remove `incus_token` from `terraform.tfvars`
+2. Add to `.gitignore`: `terraform.tfvars`
+3. Use environment variable: `export TF_VAR_incus_token="..."`
+4. Or use 1Password provider for token retrieval
+
+### Secrets Management Pattern
+```hcl
+# Use 1Password provider (already configured)
+data "onepassword_item" "incus_token" {
+  vault = "Infrastructure"
+  uuid  = "incus-token-uuid"
+}
+
+# Reference in provider
+provider "incus" {
+  token = data.onepassword_item.incus_token.password
+}
+```
+
+## Module Patterns
+
+### Container Module Template
+```hcl
+# Standard container configuration
+resource "incus_instance" "container_name" {
+  name     = var.container_name
+  image    = var.container_image
+  profiles = ["default", "base", "specific-profile"]
+
+  config = {
+    "user.access_interface" = "eth0"
+    "limits.cpu"           = var.cpu_limit
+    "limits.memory"        = var.memory_limit
+  }
+
+  # Network configuration
+  device {
+    name = "eth0"
+    type = "nic"
+    properties = {
+      nictype = "macvlan"
+      parent  = "bond0"
+      hwaddr  = format("00:16:3e:ae:%02x:%02x", var.mac_prefix, count.index)
+    }
+  }
+
+  # Storage configuration
+  device {
+    name = "storage"
+    type = "disk"
+    properties = {
+      source = var.storage_path
+      path   = "/mnt/storage"
+    }
+  }
+}
+```
+
+### Profile Module Pattern
+```hcl
+# Cloud-init profile configuration
+resource "incus_profile" "profile_name" {
+  name = var.profile_name
+
+  config = {
+    "cloud-init.user-data" = file("${path.module}/cloud-init.user-data.yaml")
+  }
+
+  # Inherit from base profile
+  device {
+    name = "root"
+    type = "disk"
+    properties = {
+      pool = "default"
+      path = "/"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### Common Issues
+1. **State Lock**: Someone else is running Terraform
+   - Wait for other operation to complete
+   - Or break lock if stale: `terraform force-unlock <lock-id>`
+
+2. **Profile Not Found**: Module depends on profile that doesn't exist
+   - Check module dependencies in `main.tf`
+   - Ensure profiles module is applied first
+
+3. **Network Conflicts**: MAC address or IP conflicts
+   - Use dynamic MAC generation
+   - Check for duplicate static IPs
+
+### Debug Commands
+```bash
+# Verbose output
+TF_LOG=DEBUG terraform plan
+
+# Validate configuration
+terraform validate
+
+# Format check
+terraform fmt -check -recursive
+
+# Show current state
+terraform state list
+terraform state show module.base.incus_network.incusbr0
+```
+
+## Future Improvements
+
+### High Priority
+1. Remove token from terraform.tfvars
+2. Add meaningful outputs to root module
+3. Create terraform.tfvars.example template
+
+### Medium Priority
+1. Implement resource tagging strategy
+2. Use more data sources instead of hardcoding
+3. Add lifecycle rules for critical resources
+4. Create generic container module to reduce duplication
+
+### Low Priority
+1. Add module versioning strategy
+2. Create dependency diagram
+3. Implement automated testing
+4. Add pre-commit hooks for formatting
+
+## Integration with Ansible
+
+After Terraform creates infrastructure:
+1. Ansible reads Terraform state (if needed)
+2. Waits for cloud-init completion
+3. Applies configuration management
+4. Deploys applications
+
+Key integration points:
+- Container names must match Ansible inventory
+- Network interfaces must align with Ansible expectations
+- Cloud-init creates users that Ansible expects

--- a/tf/modules/github-runner/main.tf
+++ b/tf/modules/github-runner/main.tf
@@ -14,7 +14,7 @@ resource "incus_instance" "github_runner" {
   profiles    = ["default", "base", "github-runner"]
 
   config = {
-    "user.access_interface" = "eth1"
+    "user.access_interface" = "eth0"
     "raw.idmap"             = <<-EOT
       uid 568 568
       gid 568 568
@@ -30,7 +30,7 @@ resource "incus_instance" "github_runner" {
     properties = {
       nictype = "macvlan"
       parent  = "bond0"
-      hwaddr  = "00:16:3e:ae:aa:0${count.index + 3}"
+      hwaddr  = format("00:16:3e:ae:aa:%02x", count.index + 3)
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixed MAC address generation to use proper hexadecimal formatting
- Corrected network interface configuration mismatch
- Prevents conflicts when scaling GitHub runners beyond 6 instances

## Changes
- Changed MAC address format from `00:16:3e:ae:aa:0${count.index + 3}` to `format("00:16:3e:ae:aa:%02x", count.index + 3)`
  - Old format would fail for index > 6 (e.g., `00:16:3e:ae:aa:010` is invalid)
  - New format properly generates hex values (e.g., `00:16:3e:ae:aa:0a` for index 7)
- Fixed `user.access_interface` from `eth1` to `eth0` to match the configured network device

## Testing
- ✅ Terraform validate passes
- ✅ Terraform plan shows only the expected changes
- ✅ MAC address generation tested for 10+ runners
- ✅ No unintended infrastructure changes

## Test Results
```
Runner 0: MAC = 00:16:3e:ae:aa:03
Runner 1: MAC = 00:16:3e:ae:aa:04
...
Runner 9: MAC = 00:16:3e:ae:aa:0c
```

This is Phase 1 of the bug fixes identified in PR #22. Phase 2 will address service dependencies and error handling.

🤖 Generated with [Claude Code](https://claude.ai/code)